### PR TITLE
Contraste le fond clair avec des cartes sombres

### DIFF
--- a/app/static/css/espace_client.css
+++ b/app/static/css/espace_client.css
@@ -2,7 +2,7 @@
     --ink: #f8f3e9;
     --ink-soft: #c5bdb1;
     --paper: #242424;
-    --cream: #171717;
+    --cream: #e7e3dc;
     --cream-deep: #342c1b;
     --gold: #d9b84a;
     --gold-dark: #c5962e;
@@ -36,9 +36,9 @@ body.client-body {
     flex-direction: column;
     color: var(--ink);
     background:
-        radial-gradient(circle at 10% 0%, rgba(217, 184, 74, 0.24), transparent 30rem),
-        radial-gradient(circle at 95% 30%, rgba(217, 184, 74, 0.15), transparent 26rem),
-        linear-gradient(145deg, #141414 0%, #211e17 48%, #151515 100%),
+        radial-gradient(circle at 10% 0%, rgba(217, 184, 74, 0.28), transparent 30rem),
+        radial-gradient(circle at 95% 30%, rgba(217, 184, 74, 0.18), transparent 26rem),
+        linear-gradient(145deg, #f4f2ee 0%, #e3ded5 48%, #f0ede7 100%),
         var(--cream);
     font-family: "DM Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     -webkit-font-smoothing: antialiased;
@@ -226,7 +226,7 @@ a:hover {
 
 .client-footer {
     padding: 21px 20px 28px;
-    color: #948a79;
+    color: #5f584f;
     font-size: 12px;
     text-align: center;
 }
@@ -243,6 +243,11 @@ a:hover {
 .login-intro {
     max-width: 560px;
     padding-left: clamp(0px, 3vw, 34px);
+    color: #171717;
+}
+
+.login-intro .page-eyebrow {
+    color: #745410;
 }
 
 .login-intro h1,
@@ -261,7 +266,7 @@ a:hover {
 .login-intro > p {
     max-width: 510px;
     margin: 25px 0 0;
-    color: var(--ink-soft);
+    color: #59534b;
     font-size: 18px;
     line-height: 1.7;
 }
@@ -277,7 +282,7 @@ a:hover {
     display: inline-flex;
     align-items: center;
     gap: 7px;
-    color: #d0c7b9;
+    color: #403b35;
     font-size: 13px;
     font-weight: 600;
 }
@@ -290,7 +295,7 @@ a:hover {
     padding: clamp(28px, 4vw, 44px);
     border: 1px solid rgba(212, 175, 55, 0.3);
     border-radius: var(--radius-lg);
-    background: linear-gradient(145deg, rgba(43, 43, 43, 0.98), rgba(25, 25, 25, 0.98));
+    background: linear-gradient(145deg, rgba(28, 28, 28, 0.99), rgba(12, 12, 12, 0.99));
     box-shadow: var(--shadow-lg);
 }
 
@@ -552,7 +557,7 @@ textarea.form-control {
     padding: clamp(24px, 4vw, 34px);
     border: 1px solid var(--line);
     border-radius: var(--radius-md);
-    background: linear-gradient(145deg, rgba(42, 42, 42, 0.98), rgba(27, 27, 27, 0.98));
+    background: linear-gradient(145deg, rgba(29, 29, 29, 0.99), rgba(15, 15, 15, 0.99));
     box-shadow: var(--shadow-sm);
 }
 
@@ -669,7 +674,7 @@ button.completion-action {
     padding: 26px;
     border: 1px solid var(--line);
     border-radius: var(--radius-md);
-    background: linear-gradient(145deg, rgba(40, 40, 40, 0.98), rgba(25, 25, 25, 0.98));
+    background: linear-gradient(145deg, rgba(27, 27, 27, 0.99), rgba(13, 13, 13, 0.99));
     box-shadow: var(--shadow-sm);
 }
 
@@ -830,7 +835,7 @@ button.completion-action {
     border-radius: 20px;
     border: 1px solid rgba(212, 175, 55, 0.32);
     color: var(--ink);
-    background: #252525;
+    background: #171717;
     box-shadow: 0 28px 80px rgba(0, 0, 0, 0.68);
 }
 
@@ -850,7 +855,7 @@ button.completion-action {
 .modal-body {
     padding: 24px;
     color: var(--ink-soft);
-    background: #252525;
+    background: #171717;
     font-size: 14px;
     line-height: 1.6;
 }

--- a/app/templates/app/page_client/base_client.html
+++ b/app/templates/app/page_client/base_client.html
@@ -7,7 +7,7 @@
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <meta name="description" content="Gérez simplement les informations de votre événement MySelfieBooth.">
    <meta name="robots" content="noindex, nofollow">
-   <meta name="theme-color" content="#141414">
+   <meta name="theme-color" content="#e7e3dc">
    <title>{% block title %}Espace client{% endblock %} | MySelfieBooth Paris</title>
    {% bootstrap_css %}
    <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Ajustement visuel

- arrière-plan gris perle clair avec halos dorés
- cartes, formulaires et modales noirs/anthracite
- textes de la zone claire adaptés
- direction artistique noir et doré conservée
- ratios de contraste de 5,44:1 à 15,57:1
- aucun changement fonctionnel